### PR TITLE
fixing error strings-to-time conversion

### DIFF
--- a/org-gantt.el
+++ b/org-gantt.el
@@ -526,14 +526,12 @@ that are converted to numbers. Then the time is calculated from the values."
                       (* 3600 (org-gantt-string-to-number hours-string))))
          (calc-days (/ ex-hours (org-gantt-hours-per-day)))
          (rest-hours (% ex-hours (org-gantt-hours-per-day)))
-         (work-free-days (plist-get org-gantt-options :work-free-days))
          (time
           (seconds-to-time
            (+ (org-gantt-string-to-number seconds-string)
               (* 60 (org-gantt-string-to-number minutes-string))
               (* 3600 (org-gantt-string-to-number hours-string))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) (org-gantt-string-to-number days-string))
-              (* 3600 (or hours-per-day (org-gantt-hours-per-day)) (- 7 (length work-free-days)))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) 30 (org-gantt-string-to-number months-string))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) 30 12 (org-gantt-string-to-number years-string))))))
     (if (= 0 (apply '+ time))


### PR DESCRIPTION
Someone introduced a bug in which a week would be added because -- for some reason -- the person included the working hours in work days in the the conversion. Seven years later, I am trying to quickly make some Gantt charts with effort estimates, and I was very confused by this bug.